### PR TITLE
Add DOI relation reporting

### DIFF
--- a/examples/api.py
+++ b/examples/api.py
@@ -1,4 +1,6 @@
+import itertools
 import os
+from collections import defaultdict
 
 from datacitekit.doi_relations import DoiRelationRelatonsReport
 from datacitekit.extractors import extract_doi
@@ -11,7 +13,6 @@ app = Flask(__name__)
 
 
 @app.route("/doi/related-graph/<path:doi>", methods=["GET"])
-def related_works(doi):
 def related_graph(doi):
     doi = extract_doi(doi)
     if not doi:
@@ -24,6 +25,22 @@ def related_graph(doi):
         return jsonify({"error": "DOI not found"}), 404
 
     report = RelatedWorkReports(full_doi_attributes)
+    return jsonify(
+        {
+            "nodes": report.aggregate_counts,
+            "edges": report.type_connection_report,
+        }
+    )
+
+
+def transpose_defaultdict(my_dict):
+    transposed = defaultdict(list)
+    for key, values in my_dict.items():
+        for value in values:
+            transposed[value].append(key)
+    return dict(transposed)
+
+
 @app.route("/doi/connections/<path:doi>", methods=["GET"])
 def connections(doi):
     doi = extract_doi(doi)
@@ -41,12 +58,13 @@ def connections(doi):
     relation_counts = dict(
         [(relation, len(values)) for relation, values in relations.items() if values]
     )
+    all_relations = transpose_defaultdict(relations)
 
     return jsonify(
         {
-            "raw": full_doi_attributes,
-            "relations": report.relations_to_doi(doi),
+            "relations": relations,
             "counts": relation_counts,
+            "all_relations:": all_relations,
         }
     )
 

--- a/examples/api.py
+++ b/examples/api.py
@@ -1,5 +1,6 @@
 import os
 
+from datacitekit.doi_relations import DoiRelationRelatonsReport
 from datacitekit.extractors import extract_doi
 from datacitekit.related_works import get_full_corpus_doi_attributes
 from datacitekit.resource_type_graph import RelatedWorkReports
@@ -11,6 +12,7 @@ app = Flask(__name__)
 
 @app.route("/doi/related-graph/<path:doi>", methods=["GET"])
 def related_works(doi):
+def related_graph(doi):
     doi = extract_doi(doi)
     if not doi:
         return jsonify({"error": "Does not match DOI format"}), 400
@@ -22,11 +24,29 @@ def related_works(doi):
         return jsonify({"error": "DOI not found"}), 404
 
     report = RelatedWorkReports(full_doi_attributes)
+@app.route("/doi/connections/<path:doi>", methods=["GET"])
+def connections(doi):
+    doi = extract_doi(doi)
+    if not doi:
+        return jsonify({"error": "Does not match DOI format"}), 400
+
+    full_doi_attributes = get_full_corpus_doi_attributes(
+        doi, RelatedWorkReports.parser, DOI_API
+    )
+    if not full_doi_attributes:
+        return jsonify({"error": "DOI not found"}), 404
+
+    report = DoiRelationRelatonsReport(full_doi_attributes)
+    relations = report.relations_to_doi(doi)
+    relation_counts = dict(
+        [(relation, len(values)) for relation, values in relations.items() if values]
+    )
 
     return jsonify(
         {
-            "nodes": report.aggregate_counts,
-            "edges": report.type_connection_report,
+            "raw": full_doi_attributes,
+            "relations": report.relations_to_doi(doi),
+            "counts": relation_counts,
         }
     )
 

--- a/src/datacitekit/doi_relations.py
+++ b/src/datacitekit/doi_relations.py
@@ -7,6 +7,42 @@ class DoiRelationRelatonsReport:
     Reports relationships between DOIs.
     """
 
+    # Relations where the subject is considered the source
+    SUBJECT_SOURCE_RELATIONS = {
+        # Citation relations
+        "cites",
+        "is-supplemented-by",
+        "references",
+        # Version relations
+        "has-version",
+        "is-new-version-of",
+        # Part relations
+        "has-part",
+        # Documentation/Description relations
+        "documents",
+        "describes",
+        # Metadata relations
+        "has-metadata",
+        # Compilation relations
+        "compiles",
+        # Review relations
+        "reviews",
+        # Derivation relations
+        "is-source-of",
+        # Continuation relations
+        "continues",
+        # Requirement relations
+        "requires",
+        # Obsolescence relations
+        "obsoletes",
+        # Collection relations
+        "collects",
+        # Translation relations
+        "has-translation",
+        # Variant relations
+        "is-original-form-of",
+    }
+
     RELATION_MAPPING = {
         # Citation relations
         "cites": ("references", "citations"),
@@ -18,12 +54,31 @@ class DoiRelationRelatonsReport:
         # Version relations
         "has-version": ("versions", "version_of"),
         "is-version-of": ("version_of", "versions"),
+        "is-new-version-of": ("new_versions", "previous_versions"),
+        "is-previous-version-of": ("previous_versions", "new_versions"),
         # Part relations
         "has-part": ("parts", "part_of"),
         "is-part-of": ("part_of", "parts"),
         # Documentation relations
         "documents": ("documents", "is_documented_by"),
         "is-documented-by": ("is_documented_by", "documents"),
+        "describes": ("descriptions", "is_described_by"),
+        "is-described-by": ("is_described_by", "descriptions"),
+        # Metadata relations
+        "has-metadata": ("metadata", "is_metadata_for"),
+        "is-metadata-for": ("is_metadata_for", "metadata"),
+        # Publication relations
+        "is-published-in": ("published_in", "publications"),
+        # Compilation relations
+        "compiles": ("compilations", "is_compiled_by"),
+        "is-compiled-by": ("is_compiled_by", "compilations"),
+        # Variant/Identity relations
+        "is-variant-form-of": ("variants", "original_forms"),
+        "is-original-form-of": ("original_forms", "variants"),
+        "is-identical-to": ("identical_to", "identical_to"),
+        # Review relations
+        "reviews": ("reviews", "is_reviewed_by"),
+        "is-reviewed-by": ("is_reviewed_by", "reviews"),
         # Derivation relations
         "is-source-of": ("sources", "derived_from"),
         "is-derived-from": ("derived_from", "sources"),
@@ -33,6 +88,15 @@ class DoiRelationRelatonsReport:
         # Requirement relations
         "requires": ("requires", "is_required_by"),
         "is-required-by": ("is_required_by", "requires"),
+        # Obsolescence relations
+        "obsoletes": ("obsoletes", "is_obsoleted_by"),
+        "is-obsoleted-by": ("is_obsoleted_by", "obsoletes"),
+        # Collection relations
+        "collects": ("collections", "is_collected_by"),
+        "is-collected-by": ("is_collected_by", "collections"),
+        # Translation relations
+        "has-translation": ("translations", "is_translation_of"),
+        "is-translation-of": ("is_translation_of", "translations"),
     }
 
     def __init__(self, data):
@@ -98,17 +162,7 @@ class DoiRelationRelatonsReport:
                 relation_type_id
             ]
             # Relations where the subject is the source
-            if relation_type_id in (
-                "cites",
-                "is-supplemented-by",
-                "references",
-                "has-version",
-                "has-part",
-                "documents",
-                "is-source-of",
-                "continues",
-                "requires",
-            ):
+            if relation_type_id in DoiRelationRelatonsReport.SUBJECT_SOURCE_RELATIONS:
                 result["source_doi"] = subj_id
                 result["target_doi"] = obj_id
             else:  # Relations where the object is the source

--- a/src/datacitekit/doi_relations.py
+++ b/src/datacitekit/doi_relations.py
@@ -1,0 +1,188 @@
+from .extractors import extract_doi
+from .utils import camel_to_hyphen_case, group_by, merge_list_dicts
+
+
+class DoiRelationRelatonsReport:
+    """
+    Reports relationships between DOIs.
+    """
+
+    RELATION_MAPPING = {
+        # Citation relations
+        "cites": ("references", "citations"),
+        "is-supplemented-by": ("references", "citations"),
+        "references": ("references", "citations"),
+        "is-cited-by": ("citations", "references"),
+        "is-supplement-to": ("citations", "references"),
+        "is-referenced-by": ("citations", "references"),
+        # Version relations
+        "has-version": ("versions", "version_of"),
+        "is-version-of": ("version_of", "versions"),
+        # Part relations
+        "has-part": ("parts", "part_of"),
+        "is-part-of": ("part_of", "parts"),
+        # Documentation relations
+        "documents": ("documents", "is_documented_by"),
+        "is-documented-by": ("is_documented_by", "documents"),
+        # Derivation relations
+        "is-source-of": ("sources", "derived_from"),
+        "is-derived-from": ("derived_from", "sources"),
+        # Continuation relations
+        "continues": ("continues", "continued_by"),
+        "is-continued-by": ("continued_by", "continues"),
+        # Requirement relations
+        "requires": ("requires", "is_required_by"),
+        "is-required-by": ("is_required_by", "requires"),
+    }
+
+    def __init__(self, data):
+        """
+        Initialize with connection data.
+
+        Args:
+            connections: List of DOI connection data
+        """
+        self.data = data
+        self.connections = self._base_connections()
+        self._source_target_format = None
+
+    def _base_connections(self):
+        dois = self.data.keys()
+        report = []
+        for doi, entry in self.data.items():
+            connections = []
+            for related in entry.get("related_identifiers", []):
+                related_doi = extract_doi(related["relatedIdentifier"])
+                if related_doi in dois:
+                    connections.append(
+                        {
+                            "related_doi": related_doi,
+                            "relation_type": related.get("relationType", "Unknown"),
+                        }
+                    )
+            report.append(
+                {
+                    "doi": doi,
+                    "connections": connections,
+                }
+            )
+        return report
+
+    @staticmethod
+    def _set_source_and_target_doi(subj_id, obj_id, relation_type_id):
+        """
+        Determines source and target DOIs and relation types based on the input IDs and relation type.
+
+        Args:
+            subj_id: The subject DOI or identifier
+            obj_id: The object DOI or identifier
+            relation_type_id: The identifier for the relationship type
+
+        Returns:
+            A dictionary containing the source DOI, target DOI, source relation type, and target relation type,
+            or None if there are missing IDs or an unhandled relation type
+        """
+        if not subj_id or not obj_id:
+            print(f"Warning: Missing ID - subject: {subj_id}, object: {obj_id}")
+            return None
+
+        result = {
+            "source_doi": None,
+            "target_doi": None,
+            "source_relation_type_id": None,
+            "target_relation_type_id": None,
+        }
+
+        if relation_type_id in DoiRelationRelatonsReport.RELATION_MAPPING:
+            source_rel, target_rel = DoiRelationRelatonsReport.RELATION_MAPPING[
+                relation_type_id
+            ]
+            # Relations where the subject is the source
+            if relation_type_id in (
+                "cites",
+                "is-supplemented-by",
+                "references",
+                "has-version",
+                "has-part",
+                "documents",
+                "is-source-of",
+                "continues",
+                "requires",
+            ):
+                result["source_doi"] = subj_id
+                result["target_doi"] = obj_id
+            else:  # Relations where the object is the source
+                result["source_doi"] = obj_id
+                result["target_doi"] = subj_id
+            result["source_relation_type_id"] = source_rel
+            result["target_relation_type_id"] = target_rel
+        else:
+            print(f"Warning: Unhandled relation type: {relation_type_id}")
+            return None
+
+        return result
+
+    @property
+    def source_target_format(self):
+        """
+        Convert connection data to source-target format, caching the result.
+
+        Returns:
+            List of dictionaries with source and target DOI information
+        """
+        if self._source_target_format is None:
+            self._source_target_format = self._convert_to_source_target_format()
+        return self._source_target_format
+
+    def _convert_to_source_target_format(self):
+        """
+        Convert the raw connection data to source-target format.
+
+        Returns:
+            List of dictionaries with source and target DOI information
+        """
+        converted = []
+        for item in self.connections:
+            source = item["doi"]
+            for connection in item["connections"]:
+                target = connection["related_doi"]
+                relationship_type = camel_to_hyphen_case(connection["relation_type"])
+                result = self._set_source_and_target_doi(
+                    source, target, relationship_type
+                )
+                if result is not None:
+                    converted.append(result)
+        return converted
+
+    def relations_to_doi(self, doi):
+        """
+        Get all relations for a specific DOI.
+
+        Args:
+            doi: The DOI to get relations for
+
+        Returns:
+            A dictionary mapping relation types to lists of related DOIs
+        """
+        s_with_doi = (
+            stpair
+            for stpair in self.source_target_format
+            if stpair["source_doi"] == doi
+        )
+        t_with_doi = (
+            stpair
+            for stpair in self.source_target_format
+            if stpair["target_doi"] == doi
+        )
+
+        sources_grouped = group_by(s_with_doi, "source_relation_type_id")
+        source_group_dois = dict(
+            [(k, [d["target_doi"] for d in v]) for k, v in sources_grouped.items()]
+        )
+
+        targets_grouped = group_by(t_with_doi, "target_relation_type_id")
+        target_group_dois = dict(
+            [(k, [d["source_doi"] for d in v]) for k, v in targets_grouped.items()]
+        )
+
+        return merge_list_dicts(source_group_dois, target_group_dois)

--- a/src/datacitekit/related_works.py
+++ b/src/datacitekit/related_works.py
@@ -4,7 +4,6 @@ from .doi_relations import DoiRelationRelatonsReport
 from .extractors import extract_doi
 from .resource_type_graph import RelatedWorkReports
 from .searchers import DoiListSearcher, DoiSearcher
-from .utils import camel_to_hyphen_case, group_by, merge_list_dicts
 
 
 def get_relation_types_grouped_by_doi(related_dois):
@@ -67,10 +66,10 @@ def _get_query():
 
 
 if __name__ == "__main__":
+    import os
     from pprint import pprint
 
-    DOI_API = "https://api.stage.datacite.org/dois/"
-    DOI_API = "https://api.datacite.org/dois/"
+    DOI_API = os.getenv("DOI_API", "https://api.stage.datacite.org/dois/")
     doi_query = _get_query()
     full_doi_attributes = get_full_corpus_doi_attributes(
         doi_query, RelatedWorkReports.parser, DOI_API

--- a/src/datacitekit/related_works.py
+++ b/src/datacitekit/related_works.py
@@ -76,16 +76,15 @@ if __name__ == "__main__":
         doi_query, RelatedWorkReports.parser, DOI_API
     )
     report = DoiRelationRelatonsReport(full_doi_attributes)
-    merged = report.relations_to_doi(doi_query)
+    relations = report.relations_to_doi(doi_query)
 
-    # merged = relations_to_doi(doi_query, report.base_connections)
-    merged_counts = dict(
-        [(relation, len(values)) for relation, values in merged.items() if values]
+    relation_counts = dict(
+        [(relation, len(values)) for relation, values in relations.items() if values]
     )
     pprint(" --- Merged counts --- ")
-    for relation, count in merged_counts.items():
+    for relation, count in relation_counts.items():
         pprint("{}: {}".format(relation, count))
-    total = sum(merged_counts.values())
+    total = sum(relation_counts.values())
     pprint("all: {}".format(total))
 
     # graph = {"nodes": report.aggregate_counts, "edges": report.type_connection_report}

--- a/src/datacitekit/related_works.py
+++ b/src/datacitekit/related_works.py
@@ -3,6 +3,7 @@
 from .extractors import extract_doi
 from .resource_type_graph import RelatedWorkReports
 from .searchers import DoiListSearcher, DoiSearcher
+from .utils import camel_to_hyphen_case, group_by, merge_list_dicts
 
 
 def get_relation_types_grouped_by_doi(related_dois):
@@ -64,8 +65,190 @@ def _get_query():
     return query
 
 
+def summarize_connections(doi, data):
+    from collections import defaultdict
+
+    # summary = defaultdict(list)
+    outgoing, incoming = defaultdict(list), defaultdict(list)
+
+    # Check each item in the data
+    for item in data:
+        # If the item's DOI matches the target DOI
+        if item["doi"] == doi:
+            connections = item["connections"]
+            # Group connections by relation_type
+            for connection in connections:
+                relation_type = connection["relation_type"]
+                related_doi = connection["related_doi"]
+                outgoing[relation_type].append(related_doi)
+
+        # Check if the target DOI appears as a related_doi in connections
+        for connection in item["connections"]:
+            if connection["related_doi"] == doi:
+                relation_type = connection["relation_type"]
+                item_doi = item["doi"]
+                incoming[relation_type].append(item_doi)
+
+    summary = {"outgoing": outgoing, "incoming": incoming}
+
+    return summary
+
+
+def set_source_and_target_doi(subj_id, obj_id, relation_type_id):
+    """
+    Determines source and target DOIs and relation types based on the input IDs and relation type.
+
+    Args:
+        subj_id: The subject DOI or identifier.
+        obj_id: The object DOI or identifier.
+        relation_type_id: The identifier for the relationship type.
+
+    Returns:
+        A dictionary containing the source DOI, target DOI, source relation type, and target relation type,
+        or None if there are missing IDs or an unhandled relation type.
+    """
+
+    if not subj_id or not obj_id:
+        print(f"Warning: Missing ID - subject: {subj_id}, object: {obj_id}")
+        return None
+
+    RELATION_MAPPING = {
+        # Citation relations
+        "cites": ("references", "citations"),
+        "is-supplemented-by": ("references", "citations"),
+        "references": ("references", "citations"),
+        "is-cited-by": ("citations", "references"),
+        "is-supplement-to": ("citations", "references"),
+        "is-referenced-by": ("citations", "references"),
+        # Version relations
+        "has-version": ("versions", "version_of"),
+        "is-version-of": ("version_of", "versions"),
+        # Part relations
+        "has-part": ("parts", "part_of"),
+        "is-part-of": ("part_of", "parts"),
+        # Documentation relations
+        "documents": ("documents", "is_documented_by"),
+        "is-documented-by": ("is_documented_by", "documents"),
+        # Derivation relations
+        "is-source-of": ("sources", "derived_from"),
+        "is-derived-from": ("derived_from", "sources"),
+        # Continuation relations
+        "continues": ("continues", "continued_by"),
+        "is-continued-by": ("continued_by", "continues"),
+        # Requirement relations
+        "requires": ("requires", "is_required_by"),
+        "is-required-by": ("is_required_by", "requires"),
+    }
+
+    result = {
+        "source_doi": None,
+        "target_doi": None,
+        "source_relation_type_id": None,
+        "target_relation_type_id": None,
+    }
+
+    if relation_type_id in RELATION_MAPPING:
+        source_rel, target_rel = RELATION_MAPPING[relation_type_id]
+        # Relations where the subject is the source
+        if relation_type_id in (
+            "cites",
+            "is-supplemented-by",
+            "references",
+            "has-version",
+            "has-part",
+            "documents",
+            "is-source-of",
+            "continues",
+            "requires",
+        ):
+            result["source_doi"] = subj_id
+            result["target_doi"] = obj_id
+        else:  # Relations where the object is the source
+            result["source_doi"] = obj_id
+            result["target_doi"] = subj_id
+        result["source_relation_type_id"] = source_rel
+        result["target_relation_type_id"] = target_rel
+    else:
+        print(f"Warning: Unhandled relation type: {relation_type_id}")
+        return None
+
+    return result
+
+
+def convert_to_source_target_format(data):
+    converted = []
+    for item in data:
+        source = item["doi"]
+        for connection in item["connections"]:
+            target = connection["related_doi"]
+            relationship_type = camel_to_hyphen_case(connection["relation_type"])
+            result = set_source_and_target_doi(source, target, relationship_type)
+            if result is not None:
+                converted.append(result)
+    return converted
+
+
+def relations_to_doi(data, doi):
+    source_target = convert_to_source_target_format(data)
+
+    # Helper function to get DOIs for a specific relation type
+    def get_outgoing_dois(relation_type):
+        return [
+            d["target_doi"]
+            for d in source_target
+            if d["source_doi"] == doi and d["source_relation_type_id"] == relation_type
+        ]
+
+    def get_incoming_dois(relation_type):
+        return [
+            d["source_doi"]
+            for d in source_target
+            if d["target_doi"] == doi and d["target_relation_type_id"] == relation_type
+        ]
+
+    return {
+        # Original relations
+        "references": get_outgoing_dois("references"),
+        "parts": get_outgoing_dois("parts"),
+        "citations": get_incoming_dois("citations"),
+        "part_of": get_incoming_dois("part_of"),
+        # New relations
+        "versions": get_outgoing_dois("versions"),
+        "version_of": get_outgoing_dois("version_of"),
+        "documents": get_outgoing_dois("documents"),
+        "is_documented_by": get_outgoing_dois("is_documented_by"),
+        "sources": get_outgoing_dois("sources"),
+        "derived_from": get_outgoing_dois("derived_from"),
+        "continues": get_outgoing_dois("continues"),
+        "continued_by": get_outgoing_dois("continued_by"),
+        "requires": get_outgoing_dois("requires"),
+        "is_required_by": get_outgoing_dois("is_required_by"),
+    }
+
+
+def doi_related_works(doi_query, connections):
+    source_target = convert_to_source_target_format(connections)
+    s_with_doi = (
+        stpair for stpair in source_target if stpair["source_doi"] == doi_query
+    )
+    t_with_doi = (
+        stpair for stpair in source_target if stpair["target_doi"] == doi_query
+    )
+    sources_grouped = group_by(s_with_doi, "source_relation_type_id")
+    source_group_dois = dict(
+        [(k, [d["target_doi"] for d in v]) for k, v in sources_grouped.items()]
+    )
+    targets_grouped = group_by(t_with_doi, "target_relation_type_id")
+    target_group_dois = dict(
+        [(k, [d["source_doi"] for d in v]) for k, v in targets_grouped.items()]
+    )
+    merged = merge_list_dicts(source_group_dois, target_group_dois)
+
+    return merged
+
+
 if __name__ == "__main__":
-    import json
+    from pprint import pprint
 
     DOI_API = "https://api.stage.datacite.org/dois/"
     DOI_API = "https://api.datacite.org/dois/"
@@ -75,5 +258,36 @@ if __name__ == "__main__":
     )
     report = RelatedWorkReports(full_doi_attributes)
 
-    graph = {"nodes": report.aggregate_counts, "edges": report.type_connection_report}
-    print(json.dumps(graph, indent=4))
+    pprint(report.base_connections)
+    pprint(" --- Summary --- ")
+    pprint(summarize_connections(doi_query, report.base_connections))
+
+    # pprint(" --- relations to doi --- ")
+    # pprint(relations_to_doi(report.base_connections, doi_query))
+    # relations = relations_to_doi(report.base_connections, doi_query)
+    #
+    # pprint("--- Summary Count --- ")
+    # pprint(
+    #     dict(
+    #         [
+    #             (relation, len(values))
+    #             for relation, values in relations.items()
+    #             if values
+    #         ]
+    #     )
+    # )
+    merged = doi_related_works(doi_query, report.base_connections)
+    merged_counts = dict(
+        [(relation, len(values)) for relation, values in merged.items() if values]
+    )
+    pprint(" --- Merged --- ")
+    pprint(merged)
+    total = 0
+    pprint(" --- Merged counts --- ")
+    for relation, count in merged_counts.items():
+        pprint("{}: {}".format(relation, count))
+        total += count
+    pprint("all: {}".format(total))
+
+    # graph = {"nodes": report.aggregate_counts, "edges": report.type_connection_report}
+    # print(json.dumps(graph, indent=4))

--- a/src/datacitekit/related_works.py
+++ b/src/datacitekit/related_works.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 
+from .doi_relations import DoiRelationRelatonsReport
 from .extractors import extract_doi
 from .resource_type_graph import RelatedWorkReports
 from .searchers import DoiListSearcher, DoiSearcher
@@ -65,188 +66,6 @@ def _get_query():
     return query
 
 
-def summarize_connections(doi, data):
-    from collections import defaultdict
-
-    # summary = defaultdict(list)
-    outgoing, incoming = defaultdict(list), defaultdict(list)
-
-    # Check each item in the data
-    for item in data:
-        # If the item's DOI matches the target DOI
-        if item["doi"] == doi:
-            connections = item["connections"]
-            # Group connections by relation_type
-            for connection in connections:
-                relation_type = connection["relation_type"]
-                related_doi = connection["related_doi"]
-                outgoing[relation_type].append(related_doi)
-
-        # Check if the target DOI appears as a related_doi in connections
-        for connection in item["connections"]:
-            if connection["related_doi"] == doi:
-                relation_type = connection["relation_type"]
-                item_doi = item["doi"]
-                incoming[relation_type].append(item_doi)
-
-    summary = {"outgoing": outgoing, "incoming": incoming}
-
-    return summary
-
-
-def set_source_and_target_doi(subj_id, obj_id, relation_type_id):
-    """
-    Determines source and target DOIs and relation types based on the input IDs and relation type.
-
-    Args:
-        subj_id: The subject DOI or identifier.
-        obj_id: The object DOI or identifier.
-        relation_type_id: The identifier for the relationship type.
-
-    Returns:
-        A dictionary containing the source DOI, target DOI, source relation type, and target relation type,
-        or None if there are missing IDs or an unhandled relation type.
-    """
-
-    if not subj_id or not obj_id:
-        print(f"Warning: Missing ID - subject: {subj_id}, object: {obj_id}")
-        return None
-
-    RELATION_MAPPING = {
-        # Citation relations
-        "cites": ("references", "citations"),
-        "is-supplemented-by": ("references", "citations"),
-        "references": ("references", "citations"),
-        "is-cited-by": ("citations", "references"),
-        "is-supplement-to": ("citations", "references"),
-        "is-referenced-by": ("citations", "references"),
-        # Version relations
-        "has-version": ("versions", "version_of"),
-        "is-version-of": ("version_of", "versions"),
-        # Part relations
-        "has-part": ("parts", "part_of"),
-        "is-part-of": ("part_of", "parts"),
-        # Documentation relations
-        "documents": ("documents", "is_documented_by"),
-        "is-documented-by": ("is_documented_by", "documents"),
-        # Derivation relations
-        "is-source-of": ("sources", "derived_from"),
-        "is-derived-from": ("derived_from", "sources"),
-        # Continuation relations
-        "continues": ("continues", "continued_by"),
-        "is-continued-by": ("continued_by", "continues"),
-        # Requirement relations
-        "requires": ("requires", "is_required_by"),
-        "is-required-by": ("is_required_by", "requires"),
-    }
-
-    result = {
-        "source_doi": None,
-        "target_doi": None,
-        "source_relation_type_id": None,
-        "target_relation_type_id": None,
-    }
-
-    if relation_type_id in RELATION_MAPPING:
-        source_rel, target_rel = RELATION_MAPPING[relation_type_id]
-        # Relations where the subject is the source
-        if relation_type_id in (
-            "cites",
-            "is-supplemented-by",
-            "references",
-            "has-version",
-            "has-part",
-            "documents",
-            "is-source-of",
-            "continues",
-            "requires",
-        ):
-            result["source_doi"] = subj_id
-            result["target_doi"] = obj_id
-        else:  # Relations where the object is the source
-            result["source_doi"] = obj_id
-            result["target_doi"] = subj_id
-        result["source_relation_type_id"] = source_rel
-        result["target_relation_type_id"] = target_rel
-    else:
-        print(f"Warning: Unhandled relation type: {relation_type_id}")
-        return None
-
-    return result
-
-
-def convert_to_source_target_format(data):
-    converted = []
-    for item in data:
-        source = item["doi"]
-        for connection in item["connections"]:
-            target = connection["related_doi"]
-            relationship_type = camel_to_hyphen_case(connection["relation_type"])
-            result = set_source_and_target_doi(source, target, relationship_type)
-            if result is not None:
-                converted.append(result)
-    return converted
-
-
-def relations_to_doi(data, doi):
-    source_target = convert_to_source_target_format(data)
-
-    # Helper function to get DOIs for a specific relation type
-    def get_outgoing_dois(relation_type):
-        return [
-            d["target_doi"]
-            for d in source_target
-            if d["source_doi"] == doi and d["source_relation_type_id"] == relation_type
-        ]
-
-    def get_incoming_dois(relation_type):
-        return [
-            d["source_doi"]
-            for d in source_target
-            if d["target_doi"] == doi and d["target_relation_type_id"] == relation_type
-        ]
-
-    return {
-        # Original relations
-        "references": get_outgoing_dois("references"),
-        "parts": get_outgoing_dois("parts"),
-        "citations": get_incoming_dois("citations"),
-        "part_of": get_incoming_dois("part_of"),
-        # New relations
-        "versions": get_outgoing_dois("versions"),
-        "version_of": get_outgoing_dois("version_of"),
-        "documents": get_outgoing_dois("documents"),
-        "is_documented_by": get_outgoing_dois("is_documented_by"),
-        "sources": get_outgoing_dois("sources"),
-        "derived_from": get_outgoing_dois("derived_from"),
-        "continues": get_outgoing_dois("continues"),
-        "continued_by": get_outgoing_dois("continued_by"),
-        "requires": get_outgoing_dois("requires"),
-        "is_required_by": get_outgoing_dois("is_required_by"),
-    }
-
-
-def doi_related_works(doi_query, connections):
-    source_target = convert_to_source_target_format(connections)
-    s_with_doi = (
-        stpair for stpair in source_target if stpair["source_doi"] == doi_query
-    )
-    t_with_doi = (
-        stpair for stpair in source_target if stpair["target_doi"] == doi_query
-    )
-    sources_grouped = group_by(s_with_doi, "source_relation_type_id")
-    source_group_dois = dict(
-        [(k, [d["target_doi"] for d in v]) for k, v in sources_grouped.items()]
-    )
-    targets_grouped = group_by(t_with_doi, "target_relation_type_id")
-    target_group_dois = dict(
-        [(k, [d["source_doi"] for d in v]) for k, v in targets_grouped.items()]
-    )
-    merged = merge_list_dicts(source_group_dois, target_group_dois)
-
-    return merged
-
-
 if __name__ == "__main__":
     from pprint import pprint
 
@@ -256,37 +75,17 @@ if __name__ == "__main__":
     full_doi_attributes = get_full_corpus_doi_attributes(
         doi_query, RelatedWorkReports.parser, DOI_API
     )
-    report = RelatedWorkReports(full_doi_attributes)
+    report = DoiRelationRelatonsReport(full_doi_attributes)
+    merged = report.relations_to_doi(doi_query)
 
-    pprint(report.base_connections)
-    pprint(" --- Summary --- ")
-    pprint(summarize_connections(doi_query, report.base_connections))
-
-    # pprint(" --- relations to doi --- ")
-    # pprint(relations_to_doi(report.base_connections, doi_query))
-    # relations = relations_to_doi(report.base_connections, doi_query)
-    #
-    # pprint("--- Summary Count --- ")
-    # pprint(
-    #     dict(
-    #         [
-    #             (relation, len(values))
-    #             for relation, values in relations.items()
-    #             if values
-    #         ]
-    #     )
-    # )
-    merged = doi_related_works(doi_query, report.base_connections)
+    # merged = relations_to_doi(doi_query, report.base_connections)
     merged_counts = dict(
         [(relation, len(values)) for relation, values in merged.items() if values]
     )
-    pprint(" --- Merged --- ")
-    pprint(merged)
-    total = 0
     pprint(" --- Merged counts --- ")
     for relation, count in merged_counts.items():
         pprint("{}: {}".format(relation, count))
-        total += count
+    total = sum(merged_counts.values())
     pprint("all: {}".format(total))
 
     # graph = {"nodes": report.aggregate_counts, "edges": report.type_connection_report}

--- a/src/datacitekit/resource_people_organization_graph.py
+++ b/src/datacitekit/resource_people_organization_graph.py
@@ -1,16 +1,9 @@
-import re
 from collections import defaultdict
 
 from glom import Coalesce, Iter, glom
 
 from .extractors import extract_doi, extract_orcid, extract_ror_id
-
-
-def camel_terms(value):
-    return re.findall(
-        "[A-Z][a-z]+|[0-9A-Z]+(?=[A-Z][a-z])|[0-9A-Z]{2,}|[a-z0-9]{2,}|[a-zA-Z0-9]",
-        value,
-    )
+from .utils import camel_terms
 
 
 def camel_to_string(value):

--- a/src/datacitekit/resource_type_graph.py
+++ b/src/datacitekit/resource_type_graph.py
@@ -1,16 +1,9 @@
-import re
 from collections import defaultdict
 
 from glom import Coalesce, Iter, glom
 
 from .extractors import extract_doi
-
-
-def camel_terms(value):
-    return re.findall(
-        "[A-Z][a-z]+|[0-9A-Z]+(?=[A-Z][a-z])|[0-9A-Z]{2,}|[a-z0-9]{2,}|[a-zA-Z0-9]",
-        value,
-    )
+from .utils import camel_terms
 
 
 class Aggregator:

--- a/src/datacitekit/searchers.py
+++ b/src/datacitekit/searchers.py
@@ -15,10 +15,10 @@ class DataCiteSearcher:
         return {
             "query": query or self.search_query,
             "disable_facets": "true",
-            "affiliation": "true",
             "include-other-registration-agencies": "true",
             "page[size]": self.page_size,
             "page[number]": page,
+            "fields[dois]": "doi,types,relatedIdentifiers",
         }
 
     def data_for_page(self, page):
@@ -63,14 +63,9 @@ class DoiListSearcher(DataCiteSearcher):
         super().__init__(search_url)
 
     def search_params(self, page=1, query=""):
-        return {
-            "ids": ",".join(self.doi_list),
-            "disable_facets": "true",
-            "affiliation": "true",
-            "include-other-registration-agencies": "true",
-            "page[size]": self.page_size,
-            "page[number]": page,
-        }
+        _search_params = super().search_params(page, query)
+        _search_params["ids"] = ",".join(self.doi_list)
+        return _search_params
 
     def _verified_doi_list(self, raw_doi_list):
         temp_list = (extract_doi(doi) for doi in raw_doi_list)

--- a/src/datacitekit/searchers.py
+++ b/src/datacitekit/searchers.py
@@ -43,9 +43,9 @@ class DataCiteSearcher:
 
 
 class DoiSearcher(DataCiteSearcher):
-    def __init__(self, doi, search_url="https://api.datacite.org/dois/"):
+    def __init__(self, doi, search_url="https://api.datacite.org/dois/", page_size=100):
         self.doi = extract_doi(doi)
-        super().__init__(search_url, self.doi_search_query)
+        super().__init__(search_url, self.doi_search_query, page_size)
 
     @property
     def doi_permutations(self):
@@ -70,3 +70,8 @@ class DoiListSearcher(DataCiteSearcher):
     def _verified_doi_list(self, raw_doi_list):
         temp_list = (extract_doi(doi) for doi in raw_doi_list)
         return [doi for doi in temp_list if doi is not None]
+
+    def search(self):
+        if not self.doi_list:
+            return []
+        return super().search()

--- a/src/datacitekit/searchers.py
+++ b/src/datacitekit/searchers.py
@@ -4,9 +4,12 @@ from .extractors import extract_doi
 
 
 class DataCiteSearcher:
-    def __init__(self, search_url="https://api.datacite.org/dois/", query=""):
+    def __init__(
+        self, search_url="https://api.datacite.org/dois/", query="", page_size=100
+    ):
         self.search_query = query
         self.search_url = search_url
+        self.page_size = page_size
 
     def search_params(self, page=1, query=""):
         return {
@@ -14,7 +17,7 @@ class DataCiteSearcher:
             "disable_facets": "true",
             "affiliation": "true",
             "include-other-registration-agencies": "true",
-            "page[size]": 100,
+            "page[size]": self.page_size,
             "page[number]": page,
         }
 
@@ -57,11 +60,17 @@ class DoiSearcher(DataCiteSearcher):
 class DoiListSearcher(DataCiteSearcher):
     def __init__(self, doi_list, search_url="https://api.datacite.org/dois/"):
         self.doi_list = self._verified_doi_list(doi_list)
-        super().__init__(search_url, self.doi_list_query)
+        super().__init__(search_url)
 
-    @property
-    def doi_list_query(self):
-        return "uid:(" + " OR ".join(self.doi_list) + ")"
+    def search_params(self, page=1, query=""):
+        return {
+            "ids": ",".join(self.doi_list),
+            "disable_facets": "true",
+            "affiliation": "true",
+            "include-other-registration-agencies": "true",
+            "page[size]": self.page_size,
+            "page[number]": page,
+        }
 
     def _verified_doi_list(self, raw_doi_list):
         temp_list = (extract_doi(doi) for doi in raw_doi_list)

--- a/src/datacitekit/utils.py
+++ b/src/datacitekit/utils.py
@@ -1,0 +1,68 @@
+import re
+from collections import defaultdict
+
+
+def camel_to_hyphen_case(camel_case_str):
+    """Convert a camelCase string to hyphen-case format.
+
+    Args:
+        camel_case_str (str): String in camelCase format
+
+    Returns:
+        str: String converted to hyphen-case format
+    """
+    return re.sub(r"(?<!^)(?=[A-Z])", "-", camel_case_str).lower()
+
+
+def merge_list_dicts(dict1, dict2):
+    """Merge two dictionaries with list values.
+
+    This function combines two dictionaries where the values are lists.
+    For each key present in either dictionary, the resulting dictionary
+    will contain a list that combines the values from both input dictionaries.
+
+    Args:
+        dict1 (dict): First dictionary with string keys and list values
+        dict2 (dict): Second dictionary with string keys and list values
+
+    Returns:
+        dict: A new dictionary containing all keys from both input dictionaries,
+              with their list values combined
+    """
+
+    result = defaultdict(list)
+    # Update with first dict
+    for key, value in dict1.items():
+        result[key].extend(value)
+    # Update with second dict
+    for key, value in dict2.items():
+        result[key].extend(value)
+
+    return dict(result)
+
+
+def group_by(items, key):
+    """Group a list of dictionaries by a specified key or function.
+
+    This function takes a list of dictionaries and groups them based on either
+    a dictionary key or a function that determines the grouping value.
+
+    Args:
+        items (list): List of dictionaries to group
+        key (Union[str, callable]): Either a string key to group by,
+            or a function that takes a dictionary and returns the grouping value
+
+    Returns:
+        dict: A dictionary where keys are the grouping values and values are
+              lists of dictionaries that share that grouping value
+
+    """
+    from collections import defaultdict
+
+    groups = defaultdict(list)
+
+    key_func = key if callable(key) else lambda x: x[key]
+    for item in items:
+        groups[key_func(item)].append(item)
+
+    return dict(groups)

--- a/src/datacitekit/utils.py
+++ b/src/datacitekit/utils.py
@@ -2,6 +2,30 @@ import re
 from collections import defaultdict
 
 
+def camel_terms(value):
+    """Split a string into its constituent terms based on camelCase and other patterns.
+
+    This function breaks down strings into component terms using a complex regular expression
+    that matches various patterns including:
+    - Words starting with capital letters followed by lowercase letters (e.g., "Camel")
+    - Groups of uppercase letters or numbers before a camelCase word (e.g., "XML" in "XMLParser")
+    - Groups of 2 or more uppercase letters or numbers (e.g., "API", "123")
+    - Groups of 2 or more lowercase letters or numbers (e.g., "api", "123")
+    - Single alphanumeric characters
+
+    Args:
+        value (str): The input string to split into terms
+
+    Returns:
+        list: A list of strings, each representing a term found in the input
+    """
+
+    return re.findall(
+        "[A-Z][a-z]+|[0-9A-Z]+(?=[A-Z][a-z])|[0-9A-Z]{2,}|[a-z0-9]{2,}|[a-zA-Z0-9]",
+        value,
+    )
+
+
 def camel_to_hyphen_case(camel_case_str):
     """Convert a camelCase string to hyphen-case format.
 


### PR DESCRIPTION
## Purpose

This PR introduces the `DoiRelationRelatonsReport` class and related functionalities to analyze and report relationships between DOIs. This includes a new API endpoint `/doi/connections/<path:doi>` to retrieve and visualize DOI connections.

This addresses the need for a more detailed and flexible way to analyze relationships between DOIs beyond the existing graph-based approach.

## Approach

1.  **`DoiRelationRelatonsReport` Class:** This class is designed to parse DOI metadata, specifically focusing on `relatedIdentifiers` to identify different types of relations (e.g., citations, versions, etc.). It normalizes these relations and provides methods to extract the connections to a given DOI.
2.  **`camel_to_hyphen_case` and `group_by` Utilities:** These utility functions are added to handle string conversions (camelCase to hyphen-case) and to group a list of dictionaries by a given key. These are used to make the relation types human-readable and for organizing the DOI relations.
3.  **`/doi/connections/<path:doi>` API Endpoint:** This new endpoint retrieves the full corpus of DOIs related to a given DOI. The endpoint utilizes the `DoiRelationRelatonsReport` to get the connections between DOIs. It also includes a `transpose_defaultdict` function to transform defaultdicts to lists.
4.  **Example Usage:** The `examples/api.py` file is updated to include the new endpoint and demonstrates how to use the `DoiRelationRelatonsReport` class to generate DOI connection reports. The `src/datacitekit/related_works.py` is updated to call the `DoiRelationRelatonsReport` class.
5.  **`src/datacitekit/utils.py`:** This file contains the new utilities.

### Key Modifications

*   Added `DoiRelationRelatonsReport` class in `src/datacitekit/doi_relations.py`
*   Added `/doi/connections/<path:doi>` endpoint to `examples/api.py`.
*   Added `camel_to_hyphen_case`, `merge_list_dicts`, `group_by` and `camel_terms` utilities to `src/datacitekit/utils.py`
*   Updated `src/datacitekit/related_works.py` to call the `DoiRelationRelatonsReport` class.
*   Updated `src/datacitekit/searchers.py` to include page\_size attribute.

### Important Technical Details

*   The `DoiRelationRelatonsReport` class defines `SUBJECT_SOURCE_RELATIONS` and `RELATION_MAPPING` to manage and normalize the different types of DOI relations.
*   The `source_target_format` property converts the raw connection data into a standardized source-target format for easier processing.
*   The `relations_to_doi` method extracts all relations for a specific DOI, categorizing them by relation type.
*   The API endpoint returns a JSON response with the DOI relations and counts.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
